### PR TITLE
fix(a11y): partial fix WCAG 1.1.1 group image and title into one link

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -25,18 +25,18 @@ export default function Card({
 
   return (
     <div>
-      <div className="aspect-square">
-        <Link href={href}>
+      <Link aria-label={title} href={href}>
+        <div className="aspect-square">
           <Image
             src={`/${image.src}`}
-            alt={image.alt}
+            alt=""
             width={200}
             height={200}
             className="object-cover w-full h-full"
           />
-        </Link>
-      </div>
-      <Link href={href}>{title}</Link>
+        </div>
+        {title}
+      </Link>
       {date && <small className="block">{formattedDate}</small>}
       {location && <small className="block">{location}</small>}
       {attribution && <small className="block">{attribution}</small>}

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -24,20 +24,20 @@ CardProps) {
 
   return (
     <div>
-      <div className="aspect-square">
-        {image && (
-          <Link href={href}>
+      <Link aria-label={title} href={href}>
+        <div className="aspect-square">
+          {image && (
             <Image
               src={`/${image.src}`}
-              alt={image.alt}
+              alt=""
               width={200}
               height={200}
               className="object-cover w-full h-full"
             />
-          </Link>
-        )}
-      </div>
-      <Link href={href}>{title}</Link>
+          )}
+        </div>
+        {title}
+      </Link>
       {dateRange && (
         <small className="block">{formatEventDateRange(dateRange)}</small>
       )}


### PR DESCRIPTION
partial fix for #3

Projects and Events lists issue Issue: alts repeat the link title.

Recommendation is to group image and title into one link, so link title doesn't repeat for screen readers.

Also, image is considered decorative in this context, so image alt should be empty, and link should have descriptive label.