### PR TITLE
fix(a11y): items on projects and events pages should be lists

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -14,7 +14,7 @@ export default function EventsIndex() {
   return (
     <>
       <h1>Events</h1>
-      <div className="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] sm:grid-cols-[repeat(auto-fit,minmax(200px,1fr))] gap-4 sm:gap-6 p-4">
+      <ul className="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] sm:grid-cols-[repeat(auto-fit,minmax(200px,1fr))] gap-4 sm:gap-6 p-4 list-none">
         {events.map(({ meta }) => (
           <EventCard
             key={meta.slug}
@@ -26,7 +26,7 @@ export default function EventsIndex() {
             images={meta.images}
           />
         ))}
-      </div>
+      </ul>
     </>
   );
 }

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -14,7 +14,7 @@ export default function EventsIndex() {
   return (
     <>
       <h1>Events</h1>
-      <div className="grid grid-cols-[repeat(auto-fit,_minmax(150px,_1fr))] sm:grid-cols-[repeat(auto-fit,_minmax(200px,_1fr))] gap-4 sm:gap-6 p-4">
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] sm:grid-cols-[repeat(auto-fit,minmax(200px,1fr))] gap-4 sm:gap-6 p-4">
         {events.map(({ meta }) => (
           <EventCard
             key={meta.slug}

--- a/app/globals.css
+++ b/app/globals.css
@@ -62,7 +62,7 @@
   }
 
   table td {
-    @apply px-4 py-2 border-solid border-1 border-gray-300;
+    @apply px-4 py-2 border-solid border border-gray-300;
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({
         <header>
           <Navbar />
         </header>
-        <main className="m-4 mt-0 mb-8 flex-grow">{children}</main>
+        <main className="m-4 mt-0 mb-8 grow">{children}</main>
         <Footer />
       </body>
     </html>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -14,7 +14,7 @@ export default function ProjectsIndex() {
   return (
     <>
       <h1>Projects</h1>
-      <div className="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] sm:grid-cols-[repeat(auto-fit,minmax(200px,1fr))] gap-4 sm:gap-6 p-4">
+      <ul className="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] sm:grid-cols-[repeat(auto-fit,minmax(200px,1fr))] gap-4 sm:gap-6 p-4 list-none">
         {projects.map(({ meta }) => (
           <Card
             key={meta.slug}
@@ -26,7 +26,7 @@ export default function ProjectsIndex() {
             images={meta.images}
           />
         ))}
-      </div>
+      </ul>
     </>
   );
 }

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -14,7 +14,7 @@ export default function ProjectsIndex() {
   return (
     <>
       <h1>Projects</h1>
-      <div className="grid grid-cols-[repeat(auto-fit,_minmax(150px,_1fr))] sm:grid-cols-[repeat(auto-fit,_minmax(200px,_1fr))] gap-4 sm:gap-6 p-4">
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] sm:grid-cols-[repeat(auto-fit,minmax(200px,1fr))] gap-4 sm:gap-6 p-4">
         {projects.map(({ meta }) => (
           <Card
             key={meta.slug}

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -24,7 +24,7 @@ export default function Card({
   const image = images?.[0];
 
   return (
-    <div>
+    <li>
       <Link aria-label={title} href={href}>
         {image && (
           <div className="aspect-square">
@@ -42,6 +42,6 @@ export default function Card({
       {date && <small className="block">{formattedDate}</small>}
       {location && <small className="block">{location}</small>}
       {attribution && <small className="block">{attribution}</small>}
-    </div>
+    </li>
   );
 }

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -23,7 +23,7 @@ CardProps) {
   const image = images && images.length > 0 ? images[0] : null;
 
   return (
-    <div>
+    <li>
       <Link aria-label={title} href={href}>
         <div className="aspect-square">
           {image && (
@@ -43,6 +43,6 @@ CardProps) {
       )}
       {/* {location && <small className="block">{location}</small>}
       {attribution && <small className="block">{attribution}</small>} */}
-    </div>
+    </li>
   );
 }


### PR DESCRIPTION
This PR changes Projects and Events items on /projects and /events into unordered lists. Previously they were divs.

Partial fix for:
- #4