### PR TITLE
Fix WCAG 2.4.7: Contact form submit button focus visibility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -53,6 +53,10 @@
     @apply focus:outline-blue-500;
   }
 
+  button {
+    @apply cursor-pointer items-center rounded-md font-bold bg-[#f96302] px-4 py-2 text-white hover:bg-gray-800 disabled:opacity-60 disabled:bg-gray-800 disabled:cursor-not-allowed;
+  }
+
   table {
     @apply mt-8 table-auto w-full border-collapse;
   }

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -171,7 +171,7 @@ export default function ContactForm({
       <button
         type="submit"
         disabled={status.type === "loading"}
-        className="mt-6 inline-flex cursor-pointer items-center rounded-md bg-black px-4 py-2 text-white hover:bg-gray-800 disabled:opacity-60"
+        className="mt-6 inline-flex"
       >
         {status.type === "loading" ? "Sending…" : "Send"}
       </button>


### PR DESCRIPTION
fixes #11

Contact form submit button had a near-black background and blue focus outline. The low contrast made active state not easily visible.

This changes the submit button to the same background orange, white font color, and font size as header nav links, which we know are accessible.

### Before

<img width="125" height="82" alt="Screenshot 2026-03-15 at 3 51 50 PM" src="https://github.com/user-attachments/assets/1935e576-ab4a-4ef8-bec0-52eab64aeb91" />

### After

<img width="120" height="85" alt="Screenshot 2026-03-15 at 3 51 30 PM" src="https://github.com/user-attachments/assets/a5145d3f-5045-4160-822a-5b48c6fd37c8" />

Also moved styles from component to global CSS `@layer base`, so that submit buttons in any additional future forms will default to the same styles.

Also updated the disabled button styles (grayed out with and without hover, and [not-allowed](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/cursor#try_it) pointer style).