### PR TITLE
fix(a11y) WCAG 2.4.4 link purpose issues

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -31,7 +31,7 @@
   }
 
   a {
-    @apply text-[#f96302] hover:underline;
+    @apply text-[#f96302] hover:underline focus:underline;
     @apply font-bold;
   }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,7 +30,8 @@ export default function Page() {
             further our collective efforts.
           </p>
           <p>
-            <Link href="/contact">Let us know</Link> if you’d like to join us.
+            To get in touch, send a message using{" "}
+            <Link href="/contact">this form</Link>.
           </p>
         </div>
         <div className="sm:col-span-3">


### PR DESCRIPTION
Partial fix for #9

This PR:

1. makes purpose more clear for contact form link from home page main content

    Changed the sentance text and link in context, from:
    <img width="326" height="55" alt="Image" src="https://github.com/user-attachments/assets/27a243c3-12a4-43e5-86a6-9e1f653dca4b" />

    to:
    <img width="459" height="70" alt="Image" src="https://github.com/user-attachments/assets/ff9900b0-55a5-479f-acb6-8842c6d4e915" />

    This uses [Technique G53 (Example 1))](https://www.w3.org/WAI/WCAG22/Techniques/general/G53#examples) to satisfy [2.4.4: Link Purpose (In Context)](https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context).

2. adds underline to link focus style as an optional, additional cue to identify links.

    Note that the existing link styles are already sufficient. They satisfy:
    > success Criterion [1.4.1 Use of color](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color) since it is relying on contrast ratio as well as color (hue) to convey that the text is a link. See https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html#related-color.

    When color alone is used to identify links, additional cues are only required on hover, which we do (see https://www.w3.org/WAI/WCAG21/Techniques/general/G183). But this optional additional cue added to the existing outline on focus can't hurt.

    Style on hover:
    <img width="141" height="63" alt="Image" src="https://github.com/user-attachments/assets/69799ac4-c74f-473c-9966-b67b5727918e" />

    Style on focus:
    <img width="132" height="80" alt="Image" src="https://github.com/user-attachments/assets/2929ff2d-271c-405d-a538-af3d067bbb03" />

    Contrast info:
    <img width="330" height="231" alt="Image" src="https://github.com/user-attachments/assets/1d66f5d7-22ab-4e8b-88a5-b15cb2a59340" />