### PR TITLE
feat(a11y): add human-readable site map page for WCAG 2.4.5 compliance

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -20,7 +20,6 @@ export default function Page() {
             alt="Portfolio Day installation and performance by Basekamp group, UArts 1999. Pictured David Dempewolf (left) and Scott Rigby (right)"
             width={600}
             height={450}
-            className="float-right ml-4 mb-4 max-w-s"
           ></Image>
         </div>
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -35,6 +35,10 @@
     @apply font-bold;
   }
 
+  footer a {
+    @apply text-gray-700 underline;
+  }
+
   ol {
     @apply list-decimal pl-8 mb-4;
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function Page() {
   return (
-    <div>
+    <>
       <h1>About</h1>
       <div className="sm:grid sm:grid-cols-8">
         <div className="sm:col-span-5 sm:mr-4">
@@ -37,12 +37,11 @@ export default function Page() {
           <Image
             width={600}
             height={450}
-            style={{ width: "600px", height: "auto" }}
             src="/EAM_600.jpg"
             alt="East Art Map, installation by Irwin, at Basekamp space, 2006."
           />
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/app/site-map/page.tsx
+++ b/app/site-map/page.tsx
@@ -1,0 +1,96 @@
+import { Metadata } from "next";
+import Link from "next/link";
+import Image from "next/image";
+import { getAllProjects } from "@/lib/projects";
+import { getAllEvents } from "@/lib/events";
+import { getAllPages } from "@/lib/pages";
+
+export const metadata: Metadata = {
+  title: "Basekamp site map",
+};
+
+export default function SitemapPage() {
+  const projects = getAllProjects();
+  const events = getAllEvents();
+  const pages = getAllPages();
+
+  return (
+    <>
+      <h1>Basekamp site map</h1>
+      <div className="sm:grid sm:grid-cols-8">
+        <div className="sm:col-span-5 sm:mr-4">
+          <p>
+            This page provides a complete guide to all content on the Basekamp
+            website.
+          </p>
+
+          <nav>
+            <ul>
+              <li>
+                <Link href="/">About</Link>
+              </li>
+              <li>
+                <Link href="/contact">Contact</Link>
+              </li>
+
+              {pages.map((page) => (
+                <li key={page.meta.slug}>
+                  <Link href={`/${page.meta.slug}`}>{page.meta.title}</Link>
+                </li>
+              ))}
+
+              <li>
+                <Link href="/projects">Projects</Link>
+                {projects.length > 0 && (
+                  <ul>
+                    {projects.map((project) => (
+                      <li key={project.meta.slug}>
+                        <Link href={`/projects/${project.meta.slug}`}>
+                          {project.meta.title}
+                        </Link>
+                        {project.meta.date && (
+                          <span className="text-gray-600 ml-2">
+                            ({new Date(project.meta.date).getFullYear()})
+                          </span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+
+              <li>
+                <Link href="/events">Events</Link>
+                {events.length > 0 && (
+                  <ul>
+                    {events.map((event) => (
+                      <li key={event.meta.slug}>
+                        <Link href={`/events/${event.meta.slug}`}>
+                          {event.meta.title}
+                        </Link>
+                        {event.meta.dateRange && (
+                          <span className="text-gray-600 ml-2">
+                            ({new Date(event.meta.dateRange.from).getFullYear()}
+                            )
+                          </span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            </ul>
+          </nav>
+        </div>
+        <div className="sm:col-span-3">
+          <Image
+            width={600}
+            height={450}
+            src="/1_1.jpg"
+            alt="Documentation photograph of map from Walk Talk Eat TalkSomeMore project, Co-organized by Basekamp & c.cred, multiple locations, 2006"
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -9,7 +9,7 @@ export default function Footer() {
       <footer className="p-4 pt-8 pb-8 bg-gray-200">
         <p className="mb-0">
           This site is licensed under{" "}
-          <Link className="text-gray-700" href={"https://creativecommons.org/licenses/by-nc-sa/4.0/"}>
+          <Link href={"https://creativecommons.org/licenses/by-nc-sa/4.0/"}>
             CC BY-NC-SA 4.0
           </Link>
           {cc.map((name) => (
@@ -21,7 +21,10 @@ export default function Footer() {
               height={18}
               className="inline ml-1"
             />
-          ))}
+          ))}{" "}
+          <Link href="/site-map" className="ml-2">
+            Site map
+          </Link>
         </p>
       </footer>
     </>


### PR DESCRIPTION
fixes https://github.com/scottrigby/basekamp-next/issues/10

Creates a new /site-map page that auto-generates from existing content
loaders (getAllProjects, getAllEvents, getAllPages). The page provides
a nested list structure matching Navbar routes, allowing users multiple
ways to discover and navigate site content. This satisfies WCAG 2.4.5
"Multiple Ways" by offering an alternative to primary navigation.

Signed-off-by: Scott Rigby <scott@r6by.com>
